### PR TITLE
Bump: to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siwa"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Tom Pusateri <pusateri@bangj.com>"]
 edition = "2018"
 license = "MIT"
@@ -8,15 +8,15 @@ description = "Sign In With Apple JWT validator library"
 homepage = "https://github.com/pusateri/siwa"
 repository = "https://github.com/pusateri/siwa.git"
 readme = "README.md"
-documentation = "https://docs.rs/siwa/0.1.2/"
+documentation = "https://docs.rs/siwa/0.2.0/"
 keywords = ["signinwithapple", "jwt", "validate"]
 categories = ["authentication"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-jsonwebtoken = "7"
-serde = {version = "1.0", features = ["derive"] }
+jsonwebtoken = "9"
+serde = { version = "1.0", features = ["derive"] }
 base64 = "0.13"
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1.2", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub async fn validate(client_id: String, base64_token: String, audience: String,
 
     let token_data = decode::<Claims>(
         str::from_utf8(&token).unwrap(),
-        &DecodingKey::from_rsa_components(&pubkey.n, &pubkey.e).to_owned().unwrap(),
+        &DecodingKey::from_rsa_components(&pubkey.n, &pubkey.e).unwrap(),
         &val,
     )?;
 


### PR DESCRIPTION
Hello,

I took a bit of time to bring this package up to date. 


Here is a summary of the changes:

- Bump to `jsonwebtoken` 9
- Make the properties of the `Claims` struct public
- Change the type of `email_verified` from `String` to `bool`
- Add `nonce_supported` of type `bool` on the `Claims` struct
- Add `audience` as an argument to the validate function
- Bump to 0.2.0. ***(Note: I haven't released any crate so far, so my excuses if I omitted something)***

I would appreciate if you could release this version once approved&merged :)

Thank you,
Gabi